### PR TITLE
Handle declarations that have no metadata

### DIFF
--- a/lib/src/annotate.dart
+++ b/lib/src/annotate.dart
@@ -202,8 +202,14 @@ class DeclarationAnnotationFacade extends AbstractAnnotationFacade {
 
   DeclarationAnnotationFacade(this._declaration);
 
-  Iterable<InstanceMirror> _getAnnotations() =>
-      _declaration.metadata;
+  Iterable<InstanceMirror> _getAnnotations() {
+    try {
+      return _declaration.metadata;
+    }
+    catch (exception) {
+      return [];
+    }
+  }
 }
 
 /// Test value for annotations


### PR DESCRIPTION
In Firefox and Chrome, when using annotations as part of another package
the annotation testing failed. Some declarations do not have metadata
and throw an exception when attempting to access it.
